### PR TITLE
Move repository locking functionality within libgit

### DIFF
--- a/interface/db.py
+++ b/interface/db.py
@@ -20,6 +20,7 @@ from flask import current_app, g
 from flask.cli import with_appcontext
 from yoyo import read_migrations
 from yoyo import get_backend
+from libgit import System
 
 from interface import local_settings
 
@@ -32,6 +33,13 @@ def get_db() -> sqlite3.Connection:
         )
         g.db.row_factory = sqlite3.Row
     return g.db
+
+
+def get_git_system() -> System:
+    """Get git system"""
+    if "git_system" not in g:
+        g.git_system = System(local_settings.BASE_DIR)
+    return g.git_system
 
 
 def close_db(e=None):

--- a/libgit/Cargo.lock
+++ b/libgit/Cargo.lock
@@ -18,10 +18,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -39,6 +54,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +107,25 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -129,16 +209,20 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libgit"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "chrono",
  "git2",
  "pyo3",
+ "serde",
+ "sled",
  "thiserror",
  "url",
  "validator",
@@ -215,6 +299,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,9 +340,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "1c571f25d3f66dd427e417cebf73dbe2361d6125cf6e3a70d143fdf97c9f5150"
 dependencies = [
  "autocfg",
  "cc",
@@ -291,9 +403,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "proc-macro-hack"
@@ -303,9 +415,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -410,6 +522,9 @@ name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -434,6 +549,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,9 +572,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,6 +599,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
 ]
 
 [[package]]
@@ -555,6 +697,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/libgit/Cargo.toml
+++ b/libgit/Cargo.toml
@@ -17,7 +17,11 @@ git2 = "0.13.23"
 url = "2.2"
 thiserror = "1.0.30"
 validator = "0.14.0"
+sled = "0.34.7"
+serde = { version = "1.0.130", features = ["derive"]}
+bincode = "1.3.3"
+chrono = { version = "0.4.19", features = ["serde"]}
 
 [dependencies.pyo3]
-version = "0.14.3"
-features = ["auto-initialize"] #, "extension-module"]
+version = "0.14.5"
+features = ["extension-module"]

--- a/libgit/Cargo.toml
+++ b/libgit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libgit"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Aravinth Manivannan <realaravinth@batsense.net>"]
 license = "AGPLv3 or later version"
 

--- a/libgit/src/lib.rs
+++ b/libgit/src/lib.rs
@@ -35,19 +35,8 @@ use pyo3::prelude::*;
 use url::Url;
 
 pub mod error;
+pub mod system;
 use error::*;
-
-#[pyclass(name = "Repo", module = "libgit")]
-pub struct Repo {
-    #[allow(dead_code)]
-    upstream: Url,
-    #[allow(dead_code)]
-    #[pyo3(get)]
-    local: String,
-    repo: Repository,
-    #[pyo3(get)]
-    path: PathBuf,
-}
 
 #[pyclass(name = "Patch", module = "libgit")]
 #[derive(Debug, Clone)]
@@ -104,14 +93,27 @@ impl Patch {
     }
 }
 
-pub const UPSTREAM_REMOTE: &str = "upstream";
-pub const LOCAL_REMOTE: &str = "local";
+pub const UPSTREAM_REMOTE: &str = "forgefed_remote_upstream";
+pub const LOCAL_REMOTE: &str = "forgefed_remote_local";
 pub const IGNORE_FILE: &str = ".fignore";
+pub const CONFIG_FILE: &str = "forgefed.toml";
+
+#[pyclass(name = "Repo", module = "libgit")]
+pub struct Repo {
+    #[allow(dead_code)]
+    upstream: Url,
+    #[allow(dead_code)]
+    #[pyo3(get)]
+    local: String,
+    repo: Repository,
+    #[pyo3(get)]
+    path: PathBuf,
+}
 
 #[pymethods]
 impl Repo {
     /// Add remote to repository
-    pub fn add_remote(&self, name: &str, url: &str) -> FResult<()> {
+    pub(crate) fn add_remote(&self, name: &str, url: &str) -> FResult<()> {
         match self.repo.find_remote(name) {
             Err(_) => {
                 let mut remote = self.repo.remote(name, &url)?;
@@ -135,7 +137,7 @@ impl Repo {
     /// ```rust,no_run
     /// let repo = Repo::new("/srv/ff/",git@git.batsense.net:realaravinth/tmp.git", "https://github.com/forgefedv2/interface").unwrap();
     /// ```
-    pub fn new(base: &str, local: String, upstream: String) -> FResult<Self> {
+    pub(crate) fn new(base: &str, local: String, upstream: String) -> FResult<Self> {
         fn set_path(base: &str, upstream: &Url) -> FResult<PathBuf> {
             let domain = match upstream.domain() {
                 Some(d) => d,
@@ -173,7 +175,8 @@ impl Repo {
         Ok(obj)
     }
 
-    pub fn fetch_upstream(&self) -> FResult<()> {
+    /// `git fetch upstream <default-branch>`
+    pub(crate) fn fetch_upstream(&self) -> FResult<()> {
         let mut remote = connect_upstream(&self)?;
         let default_branch = remote.default_branch()?;
         remote.fetch(&[default_branch.as_str().unwrap()], None, None)?;
@@ -181,6 +184,7 @@ impl Repo {
         Ok(())
     }
 
+    /// get default branch of a repository from the upstream remote
     pub fn default_branch(&self) -> FResult<String> {
         let mut remote = connect_upstream(&self)?;
         let default_branch = remote.default_branch()?;
@@ -188,7 +192,8 @@ impl Repo {
         Ok(default_branch.as_str().unwrap().to_string())
     }
 
-    pub fn push_local(&self, branch: &str) -> FResult<()> {
+    /// push changes to local repository
+    pub(crate) fn push_local(&self, branch: &str) -> FResult<()> {
         let mut upstream = connect_upstream(&self)?;
         let mut local = connect_local(&self)?;
 
@@ -207,7 +212,8 @@ impl Repo {
         Ok(())
     }
 
-    pub fn apply_patch(
+    /// Apply a patch
+    pub(crate) fn apply_patch(
         &self,
         patch: Patch,
         admin: &InterfaceAdmin,
@@ -254,7 +260,8 @@ impl Repo {
         Ok(())
     }
 
-    pub fn process_patch(&self, patch: String, branch_name: String) -> FResult<String> {
+    /// process patch for federated transport
+    pub(crate) fn process_patch(&self, patch: String, branch_name: String) -> FResult<String> {
         let buf: Vec<u8> = patch.into();
         let diff = git2::Diff::from_buffer(&buf)?;
         let head = self.repo.head()?;
@@ -312,6 +319,7 @@ impl Repo {
         Ok(patch)
     }
 }
+
 fn rm_file(repo: &Repo, file: &DiffFile) -> FResult<()> {
     if let Some(path) = file.path() {
         let path = repo.path.clone().join(path);
@@ -350,6 +358,7 @@ fn connect_local(repo: &Repo) -> FResult<Remote> {
 #[pyo3(name = "libgit")]
 fn my_extension(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Repo>()?;
+    m.add_class::<system::System>()?;
     m.add_class::<InterfaceAdmin>()?;
     m.add_class::<Patch>()?;
     m.add("RemoteNameExists", py.get_type::<RemoteNameExists>())?;
@@ -362,4 +371,18 @@ fn my_extension(py: Python, m: &PyModule) -> PyResult<()> {
         py.get_type::<error::InvalidUpstreamUrl>(),
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env::temp_dir;
+
+    const UPSTREAM: &str = "https://github.com/forgefedv2/forgedfed-spec";
+
+    #[test]
+    fn everything_works() {
+        let base = temp_dir().join("everything_works");
+    }
 }

--- a/libgit/src/lib.rs
+++ b/libgit/src/lib.rs
@@ -37,6 +37,7 @@ use url::Url;
 pub mod error;
 pub mod system;
 use error::*;
+pub use system::System;
 
 #[pyclass(name = "Patch", module = "libgit")]
 #[derive(Debug, Clone)]
@@ -358,7 +359,7 @@ fn connect_local(repo: &Repo) -> FResult<Remote> {
 #[pyo3(name = "libgit")]
 fn my_extension(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Repo>()?;
-    m.add_class::<system::System>()?;
+    m.add_class::<System>()?;
     m.add_class::<InterfaceAdmin>()?;
     m.add_class::<Patch>()?;
     m.add("RemoteNameExists", py.get_type::<RemoteNameExists>())?;

--- a/libgit/src/system.rs
+++ b/libgit/src/system.rs
@@ -28,15 +28,6 @@ use sled::{Db, Tree};
 use crate::error::*;
 use crate::{InterfaceAdmin, Patch, Repo};
 
-#[pyclass(name = "System", module = "libgit")]
-pub struct System {
-    #[allow(dead_code)]
-    db: Db,
-    pub remotes: Tree,
-    pub lock: Tree,
-    pub base: String,
-}
-
 #[derive(Deserialize, Serialize)]
 struct Lock {
     is_locked: bool,
@@ -57,6 +48,16 @@ impl Lock {
     }
 }
 
+#[pyclass(name = "System", module = "libgit")]
+#[derive(Debug, Clone)]
+pub struct System {
+    #[allow(dead_code)]
+    db: Db,
+    pub remotes: Tree,
+    pub lock: Tree,
+    pub base: String,
+}
+
 #[pymethods]
 impl System {
     #[new]
@@ -74,7 +75,7 @@ impl System {
         })
     }
 
-    pub fn init_repo(&self, base: &str, local: String, upstream: String) -> FResult<()> {
+    pub fn init_repo(&self, local: String, upstream: String) -> FResult<()> {
         let lock = Lock::new(false);
         self.lock
             .insert(local.as_bytes(), bincode::serialize(&lock).unwrap())
@@ -84,7 +85,7 @@ impl System {
             .insert(local.as_bytes(), upstream.as_bytes())
             .unwrap();
 
-        Repo::new(base, local, upstream)?;
+        Repo::new(&self.base, local, upstream)?;
         Ok(())
     }
 

--- a/libgit/src/system.rs
+++ b/libgit/src/system.rs
@@ -1,0 +1,188 @@
+/* git interface for forgefedv2 interface
+ * Bridges software forges to create a distributed software development environment
+ * Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use std::fs;
+use std::path::Path;
+use std::str;
+
+use chrono::DateTime;
+use chrono::Utc;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+use sled::{Db, Tree};
+
+use crate::error::*;
+use crate::{InterfaceAdmin, Patch, Repo};
+
+#[pyclass(name = "System", module = "libgit")]
+pub struct System {
+    #[allow(dead_code)]
+    db: Db,
+    pub remotes: Tree,
+    pub lock: Tree,
+    pub base: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Lock {
+    is_locked: bool,
+    time: Option<DateTime<Utc>>,
+}
+
+impl Lock {
+    fn new(is_locked: bool) -> Self {
+        if is_locked {
+            let time = Some(Utc::now());
+            Self { is_locked, time }
+        } else {
+            Self {
+                is_locked,
+                time: None,
+            }
+        }
+    }
+}
+
+#[pymethods]
+impl System {
+    #[new]
+    pub fn new(base: &str) -> FResult<Self> {
+        let path = Path::new(&base).join("interface_repo_data");
+        fs::create_dir_all(&path)?;
+        let db = sled::open(path).unwrap();
+        let remotes = db.open_tree("remotes").unwrap();
+        let lock = db.open_tree("lock").unwrap();
+        Ok(Self {
+            base: base.to_owned(),
+            db,
+            remotes,
+            lock,
+        })
+    }
+
+    pub fn init_repo(&self, base: &str, local: String, upstream: String) -> FResult<()> {
+        let lock = Lock::new(false);
+        self.lock
+            .insert(local.as_bytes(), bincode::serialize(&lock).unwrap())
+            .unwrap();
+
+        self.remotes
+            .insert(local.as_bytes(), upstream.as_bytes())
+            .unwrap();
+
+        Repo::new(base, local, upstream)?;
+        Ok(())
+    }
+
+    pub fn with_local(&self, local: &str) -> FResult<Option<Repo>> {
+        if let Ok(Some(upstream)) = self.remotes.get(local) {
+            let repo = Repo::new(
+                &self.base,
+                local.to_owned(),
+                str::from_utf8(&*upstream).unwrap().to_owned(),
+            )?;
+            Ok(Some(repo))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn with_upstream(&self, upstream: &str) -> FResult<Option<Repo>> {
+        let upstream_bytes = upstream.as_bytes();
+        let config = self.remotes.iter().find(|rec| {
+            if let Ok((_k, v)) = rec {
+                v == upstream_bytes
+            } else {
+                false
+            }
+        });
+
+        if let Some(Ok((local, _upstream))) = config {
+            let local = str::from_utf8(&*local).unwrap().to_owned();
+            let repo = Repo::new(&self.base, local, upstream.to_owned())?;
+            Ok(Some(repo))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn fetch_upstream(&self, repo: &Repo) -> FResult<()> {
+        let cb = || repo.fetch_upstream();
+        run_with_repo(&self, repo, cb)
+    }
+
+    pub fn process_patch(
+        &self,
+        repo: &Repo,
+        patch: String,
+        branch_name: String,
+    ) -> FResult<String> {
+        let cb = move || repo.process_patch(patch, branch_name);
+        run_with_repo(&self, repo, cb)
+    }
+
+    pub fn apply_patch(
+        &self,
+        repo: &Repo,
+        patch: Patch,
+        admin: &InterfaceAdmin,
+        branch_name: String,
+    ) -> FResult<()> {
+        let cb = move || repo.apply_patch(patch, admin, branch_name);
+        run_with_repo(&self, repo, cb)
+    }
+
+    pub fn push_local(&self, repo: &Repo, branch: &str) -> FResult<()> {
+        let cb = || repo.push_local(branch);
+        run_with_repo(&self, repo, cb)
+    }
+
+    pub fn add_remote(&self, repo: &Repo, name: &str, url: &str) -> FResult<()> {
+        let cb = || repo.add_remote(name, url);
+        run_with_repo(&self, repo, cb)
+    }
+}
+
+fn run_with_repo<T, F: FnOnce() -> T>(sys: &System, repo: &Repo, f: F) -> T {
+    let local_bytes = &repo.local.as_bytes();
+    let lock = sys.lock.get(&local_bytes).unwrap().unwrap();
+    let de_lock: Lock = bincode::deserialize(&lock).unwrap();
+    if !de_lock.is_locked {
+        let new_lock = bincode::serialize(&Lock::new(true)).unwrap();
+        let new_lock = new_lock.as_slice();
+        sys.lock
+            .compare_and_swap(&local_bytes, Some(lock.as_ref()), Some(new_lock))
+            .unwrap()
+            .unwrap();
+        let resp = (f)();
+        sys.lock
+            .compare_and_swap(&local_bytes, Some(new_lock), Some(lock.as_ref()))
+            .unwrap()
+            .unwrap();
+        resp
+    } else {
+        // One possible solution is implementing backoff loop which checks if repository is
+        // available. But that could mess state up with actions that are sequential.
+        //
+        // For example:
+        // A patch arrives for a repository. Repository is unavailable so it's blocked.
+        // While being blocked, second patch arrives. It is possible that second patch detects
+        // that the repository is available before the first one does, causing a race
+        // condition.
+        unimplemented!("When repo is locked")
+    }
+}

--- a/migrations/20211023_01_0W52q-event-subscriptions.py
+++ b/migrations/20211023_01_0W52q-event-subscriptions.py
@@ -9,7 +9,6 @@ __depends__ = {}
 steps = [
     step("""
     CREATE TABLE IF NOT EXISTS interface_repositories(
-        is_locked VARCHAR(100) DEFAULT NULL,
         html_url VARCHAR(3000) UNIQUE NOT NULL,
         ID INTEGER PRIMARY KEY NOT NULL
     );


### PR DESCRIPTION
Locks are necessary to ensure concurrent operations on Git repositories
don't cause corruption. So far, we've been doing it within `interface` but I think it's better to handle locking mechanism within `libgit` itself.

Current implementation uses [sled](https://sled.rs/), a low level, fast embedded db to store repository metadata like upstream and local urls along with locking information. 

All stateful operations are now conducted through `System`, which provides a safer interface to perform Git operations by restricting concurrent ops through locking and unlocking and proxying methods on `Repo`.

`System` also provides creating `Repo` objects with just `upstream` or `local` URLs.