### PR TITLE
Encapsulate fork implementation

### DIFF
--- a/interface/forges/base.py
+++ b/interface/forges/base.py
@@ -25,6 +25,7 @@ from interface.forges.payload import RepositoryInfo, CreatePullrequest, CreateIs
 from interface.forges.utils import clean_url
 from interface.ns import NameService
 from interface.error import Error
+from interface.db import get_db
 
 
 class Forge:
@@ -96,8 +97,11 @@ class Forge:
         """
         raise NotImplementedError
 
-    def fork(self, owner: str, repo: str):
-        """Fork a repository"""
+    def fork_inner(self, owner: str, repo: str) -> str:
+        """
+        Forge-specific implementation of repository forking.
+        Returns repository name where the fork resides.
+        """
         raise NotImplementedError
 
     def close_pr(self, owner: str, repo: str):

--- a/interface/forges/gitea.py
+++ b/interface/forges/gitea.py
@@ -238,7 +238,7 @@ class Gitea(Forge):
         response = requests.request("POST", url, json=payload, headers=headers)
         return response.json()["html_url"]
 
-    def fork(self, owner: str, repo: str):
+    def fork_inner(self, owner: str, repo: str) -> str:
         """Fork a repository"""
         url = self._get_url(format("/repos/%s/%s/forks" % (owner, repo)))
         print(url)

--- a/migrations/20211223_01_pFC7s-interface-forks.py
+++ b/migrations/20211223_01_pFC7s-interface-forks.py
@@ -1,0 +1,17 @@
+"""
+interface forks
+"""
+
+from yoyo import step
+
+__depends__ = {'20211024_01_h2IuD-interface-jobs'}
+
+steps = [
+    step("""
+    CREATE TABLE IF NOT EXISTS interface_forks(
+        parent_owner VARCHAR(100) NOT NULL,
+        parent_repo_name VARCHAR(100) NOT NULL,
+        fork_repo_name VARCHAR(100) PRIMARY KEY NOT NULL
+    );
+    """),
+]

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -54,8 +54,10 @@ from tests.forges.gitea.test_utils import (
 )
 
 
-def test_get_repository(client):
+def test_get_repository(client, requests_mock):
     """Test version meta route"""
+    register_ns(requests_mock)
+    register_gitea(requests_mock)
     g = Gitea()
     host = settings.GITEA.host
     repo_url = f"{host}/foo/bar"
@@ -157,6 +159,7 @@ def test_create_repository(requests_mock):
 
 def test_get_local_push_and_html_url(requests_mock):
     register_ns(requests_mock)
+    register_gitea(requests_mock)
     g = Gitea()
     host = settings.GITEA.host
     host = urlparse(clean_url(host))

--- a/tests/forges/test_base.py
+++ b/tests/forges/test_base.py
@@ -81,7 +81,7 @@ def test_base_forge():
         forge.create_pull_request(pr=pr)
 
     with pytest.raises(NotImplementedError) as _:
-        forge.fork("", "")
+        forge.fork_inner("", "")
 
     with pytest.raises(NotImplementedError) as _:
         forge.close_pr("", "")

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -19,11 +19,13 @@ from interface.git import get_forge
 from interface.utils import clean_url
 
 from tests.test_utils import register_ns
+from tests.forges.gitea.test_utils import register_gitea
 
 
 def test_ns(app, requests_mock):
     """Test ns"""
     register_ns(requests_mock)
+    register_gitea(requests_mock)
     forge = get_forge().forge.get_forge_url()
     config_interface_url = settings.SERVER.domain
 


### PR DESCRIPTION
When forking a repository within the same forge, a name clash could
arise. To overcome this issue, we'll have to retry with a different,
unique name. The only way we can refer to this fork from then on is if
we store it's name in the database.

To make this possible, forge-specific operation will be defined in
interface.forges.base.Forge.fork_inner but users(callers) will use the
interface provided by `interface.git.fork`, which stores the fork's
name in the database.