### PR TITLE
Coverage ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - "*"
+      - "!gh-pages"
 
 jobs:
   build_and_test:
@@ -53,4 +54,11 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v2
         with:
-          files: ./libgit/target/lcov.info,coverage.xml
+          files: ./libgit/target/lcov.info
+          flags: libgit
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: coverage.xml
+          flags: interface

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,9 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - "*"
+      - "!gh-pages"
+
 
 jobs:
   build_and_test:

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -35,7 +35,15 @@ build_and_test() {
 		./target/debug/ \
 		-s . -t lcov --branch \
 		--ignore-not-existing \
+        --ignore src/error.rs \
 		--ignore "../*" -o target/lcov.info
+
+	$GRCOV . -s . --binary-path \
+		./target/debug/ \
+		-t html --branch \
+		--ignore-not-existing \
+        --ignore src/error.rs \
+		-o ./target/debug/coverage/ || true
 }
 
 run_coverage() {


### PR DESCRIPTION
## Changes
- `libgit` and `interface` coverage reports are uploaded separately with unique flags for each
- HTML coverage report is generated for `libgit` during the default coverage run

> Can be merged independently