### PR TITLE
Migrate subscription endpoint to use interface.db.* to talk to database

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -21,9 +21,7 @@ job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgefed.io" # Default discovery service URL
 
 [default.server]
-domain = "localhost" # Domain at which this instance will listen from
-ip = "0.0.0.0" # IP at which this server will listen from
-port = 7000 # port at which this server will listen from
+url = "http://localhost:7000" # URL at which this interface will run
 
 [testing]
 forge = "gitea"
@@ -47,6 +45,4 @@ job_runner_delay = 1  ## in seconds
 northstar = "https://northstar.forgefed.io" # Default discovery service URL
 
 [testing.server]
-domain = "localhost" # Domain at which this instance will listen from
-ip = "0.0.0.0" # IP at which this server will listen from
-port = 7000 # port at which this server will listen from
+url = "http://localhost:7000" # URL at which this interface will run

--- a/interface/__main__.py
+++ b/interface/__main__.py
@@ -24,5 +24,6 @@ from interface.runner import runner
 if __name__ == "__main__":
     app = create_app()
     worker = runner.init_app(app)
-    app.run(threaded=True, host=settings.SERVER.ip, port=settings.SERVER.port)
+    port = int(settings.SERVER.url.split(":").pop())
+    app.run(threaded=True, host=settings.SERVER.ip, port=port)
     worker.kill()

--- a/interface/app.py
+++ b/interface/app.py
@@ -26,7 +26,8 @@ from interface import db
 from interface import runner
 from interface.api.v1 import bp
 from interface.meta import bp as meta_bp
-from interface.auth import keygen_bp
+from interface.auth import keygen_bp, KeyPair
+from interface.db import DBInterfaces
 
 
 def create_app(test_config=None):
@@ -50,6 +51,10 @@ def create_app(test_config=None):
         pass
 
     db.init_app(app)
+
+    with app.app_context():
+        key = KeyPair.loadkey().to_base64_public()
+        DBInterfaces(url=settings.SERVER.url, public_key=key).save()
 
     @app.after_request
     def flock_google(response):

--- a/interface/db/__init__.py
+++ b/interface/db/__init__.py
@@ -18,3 +18,4 @@ from .interfaces import DBInterfaces
 from .repo import DBRepo
 from .issues import DBIssue
 from .users import DBUser
+from .subscriptions import DBSubscribe

--- a/interface/db/interfaces.py
+++ b/interface/db/interfaces.py
@@ -44,13 +44,13 @@ class DBInterfaces:
             "SELECT ID, public_key  FROM interfaces WHERE url = ?;",
             (url,),
         ).fetchone()
-        if all([data, len(data) > 0]):
-            return cls(
-                id=data[0],
-                public_key=data[1],
-                url=url,
-            )
-        return None
+        if data is None:
+            return None
+        return cls(
+            id=data[0],
+            public_key=data[1],
+            url=url,
+        )
 
     @classmethod
     def load_from_pk(cls, public_key: str):
@@ -61,10 +61,11 @@ class DBInterfaces:
             "SELECT ID, url  FROM interfaces WHERE public_key = ?;",
             (public_key,),
         ).fetchone()
-        if all([data, len(data) > 0]):
-            return cls(
-                id=data[0],
-                url=data[1],
-                public_key=public_key,
-            )
-        return None
+        if data is None:
+            return None
+
+        return cls(
+            id=data[0],
+            url=data[1],
+            public_key=public_key,
+        )

--- a/interface/db/repo.py
+++ b/interface/db/repo.py
@@ -49,9 +49,9 @@ class DBRepo:
                 SELECT ID from gitea_forge_repositories
                 WHERE name = ? AND owner = ?;
             """,
-            (owner, name),
+            (name, owner),
         ).fetchone()
-        if any([data is None, len(data) != 1]):
+        if data is None:
             return None
         cls.name = name
         cls.owner = owner

--- a/interface/db/subscriptions.py
+++ b/interface/db/subscriptions.py
@@ -1,0 +1,95 @@
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from dataclasses import dataclass
+
+from .repo import DBRepo
+from .interfaces import DBInterfaces
+from .conn import get_db
+
+
+@dataclass
+class DBSubscribe:
+    """Issue information as stored in database"""
+
+    repository: DBRepo
+    subscriber: DBInterfaces
+
+    def save(self):
+        """Save Issue to database"""
+        self.repository.save()
+        self.subscriber.save()
+
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO subscriptions
+                ( repository_id, interface_id)
+            VALUES (
+                (SELECT ID FROM gitea_forge_repositories WHERE owner  = ? AND name = ?),
+                (SELECT ID FROM interfaces WHERE url  = ?)
+            )
+            """,
+            (
+                self.repository.owner,
+                self.repository.name,
+                self.subscriber.url,
+            ),
+        )
+        conn.commit()
+        assert self.load(self.repository) is not None
+        print("Saved subscriber")
+
+    @classmethod
+    def load(cls, repository: DBRepo):
+        """Load issue from database"""
+        conn = get_db()
+        cur = conn.cursor()
+        data = cur.execute(
+            """
+         SELECT
+             interfaces.url,
+             interfaces.public_key,
+             interfaces.ID
+        FROM
+             subscriptions AS subscriptions
+        INNER JOIN interfaces AS interfaces
+            ON subscriptions.interface_id = interfaces.ID
+        WHERE
+            subscriptions.repository_id = (
+                SELECT ID FROM gitea_forge_repositories WHERE owner = ? AND name = ?
+            );
+        """,
+            (repository.owner, repository.name),
+        ).fetchall()
+        if data is None:
+            return None
+
+        subscribers = []
+        for interface in data:
+            subscribers.append(
+                cls(
+                    subscriber=DBInterfaces(
+                        url=interface[0],
+                        public_key=interface[2],
+                        id=interface[1],
+                    ),
+                    repository=repository,
+                )
+            )
+
+        if len(subscribers) == 0:
+            return None
+        return subscribers

--- a/interface/forges/gitea/gitea.py
+++ b/interface/forges/gitea/gitea.py
@@ -296,29 +296,6 @@ class Gitea(Forge):
 
         raise F_D_FORGE_UNKNOWN_ERROR
 
-    @staticmethod
-    def _get_issue_index(issue_url, repo: str) -> int:
-        issue_frag = "issues/"
-        if issue_frag not in issue_url:
-            raise F_D_INVALID_ISSUE_URL
-        parsed = urlparse(trim_url(issue_url))
-        path = parsed.path
-        fragments = path.split(f"{repo}/{issue_frag}")
-        if len(fragments) < 2:
-            raise F_D_INVALID_ISSUE_URL
-
-        index = fragments[1]
-
-        if not index.isdigit():
-            if "/" in index:
-                index = index.split("/")[0]
-                if not index.isdigit():
-                    raise F_D_INVALID_ISSUE_URL
-            else:
-                raise F_D_INVALID_ISSUE_URL
-
-        return int(index)
-
     def comment_on_issue(self, owner: str, repo: str, issue_url: str, body: str):
         headers = self._auth()
         (owner, repo) = self.get_fetch_remote(issue_url)

--- a/interface/forges/gitea/utils.py
+++ b/interface/forges/gitea/utils.py
@@ -1,0 +1,49 @@
+"""
+Gitea-specific utilities
+"""
+# Bridges software forges to create a distributed software development environment
+# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from urllib.parse import urlparse
+
+from interface.utils import trim_url
+from interface.forges.base import F_D_INVALID_ISSUE_URL
+
+
+def get_issue_index(issue_url, repo: str) -> int:
+    """
+    Get isssue index from issue URL
+    https://git.batsense.net/{owner}/{repo}/issues/{id} returns {id}
+    """
+    issue_frag = "issues/"
+    if issue_frag not in issue_url:
+        raise F_D_INVALID_ISSUE_URL
+    parsed = urlparse(trim_url(issue_url))
+    path = parsed.path
+    fragments = path.split(f"{repo}/{issue_frag}")
+    if len(fragments) < 2:
+        raise F_D_INVALID_ISSUE_URL
+
+    index = fragments[1]
+
+    if not index.isdigit():
+        if "/" in index:
+            index = index.split("/")[0]
+            if not index.isdigit():
+                raise F_D_INVALID_ISSUE_URL
+        else:
+            raise F_D_INVALID_ISSUE_URL
+
+    return int(index)

--- a/interface/ns.py
+++ b/interface/ns.py
@@ -71,7 +71,7 @@ class NameService:
         url = "interface/register"
         url = self._get_url(url)
         payload = {
-            "interface_url": settings.SERVER.domain,
+            "interface_url": settings.SERVER.url,
             "forge_url": [self.forge_url],
         }
         resp = requests.post(url, json=payload)

--- a/interface/runner/runner.py
+++ b/interface/runner/runner.py
@@ -55,7 +55,7 @@ class Runner:
                 INSERT OR IGNORE INTO interface_jobs_run
                     (this_interface_url, last_run) VALUES (?, ?);
                 """,
-                (settings.SERVER.domain, str(last_run)),
+                (settings.SERVER.url, str(last_run)),
             )
             conn.commit()
         self.thread = threading.Thread(target=self._background_job)
@@ -80,7 +80,7 @@ class Runner:
             cur = conn.cursor()
             cur.execute(
                 "UPDATE interface_jobs_run set last_run = ? WHERE this_interface_url = ?;",
-                (str(last_run), settings.SERVER.domain),
+                (str(last_run), settings.SERVER.url),
             )
             conn.commit()
 
@@ -90,7 +90,7 @@ class Runner:
             cur = conn.cursor()
             res = cur.execute(
                 "SELECT last_run FROM interface_jobs_run WHERE this_interface_url = ?;",
-                (settings.SERVER.domain,),
+                (settings.SERVER.url,),
             ).fetchone()
             return res[0]
 

--- a/migrations/20211023_01_0W52q-event-subscriptions.py
+++ b/migrations/20211023_01_0W52q-event-subscriptions.py
@@ -10,28 +10,10 @@ steps = [
     ## local repositories: repositories on the forge that this interface services
     step(
         """
-    CREATE TABLE IF NOT EXISTS local_repositories(
-        html_url VARCHAR(3000) UNIQUE NOT NULL,
-        ID INTEGER PRIMARY KEY NOT NULL
-    );
-
-    """
-    ),
-    # TODO get public key
-    step(
-        """
         CREATE TABLE IF NOT EXISTS interfaces(
             url VARCHAR(3000) UNIQUE NOT NULL,
             public_key TEXT UNIQUE NOT NULL,
             ID INTEGER PRIMARY KEY NOT NULL
-        );
-    """
-    ),
-    step(
-        """
-        CREATE TABLE IF NOT EXISTS subscriptions(
-            repository_id INTEGER NOT NULL REFERENCES local_repositories(ID) ON DELETE CASCADE,
-            interface_id INTEGER NOT NULL REFERENCES interfaces(ID) ON DELETE CASCADE
         );
     """
     ),

--- a/migrations/20211226_01_zx3oY-forge-data.py
+++ b/migrations/20211226_01_zx3oY-forge-data.py
@@ -23,7 +23,8 @@ steps = [
         CREATE TABLE IF NOT EXISTS gitea_forge_repositories(
             owner VARCHAR(250) NOT NULL,
             name VARCHAR(250) NOT NULL,
-            ID INTEGER PRIMARY KEY NOT NULL
+            ID INTEGER PRIMARY KEY NOT NULL,
+            UNIQUE(owner, name)
         );
     """
     ),
@@ -62,6 +63,15 @@ steps = [
             parent_of REFERENCES issue_comments(ID),
             is_native BOOLEAN NOT NULL DEFAULT TRUE,
             signed_by INTEGER REFERENCES interfaces(ID) ON DELETE CASCADE DEFAULT NULL
+        );
+    """
+    ),
+    step(
+        """
+        CREATE TABLE IF NOT EXISTS subscriptions(
+            repository_id INTEGER NOT NULL REFERENCES gitea_forge_repositories(ID) ON DELETE CASCADE,
+            interface_id INTEGER NOT NULL REFERENCES interfaces(ID) ON DELETE CASCADE,
+            UNIQUE(repository_id, interface_id)
         );
     """
     ),

--- a/tests/db/test_interface.py
+++ b/tests/db/test_interface.py
@@ -12,8 +12,11 @@
 # GNU Affero General Public License for more details.
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from dynaconf import settings
+
 from interface.db.interfaces import DBInterfaces
 from interface.auth import KeyPair
+from interface.app import app
 
 
 def cmp_interface(lhs: DBInterfaces, rhs: DBInterfaces) -> bool:
@@ -34,3 +37,12 @@ def test_interface(client):
     assert cmp_interface(from_url, from_key) is True
     assert cmp_interface(from_url, data) is True
     assert from_url.id == from_key.id
+
+
+def test_interface_self_resgistration(app, client, requests_mock):
+    with app.app_context():
+        key = KeyPair.loadkey().to_base64_public()
+    from_key = DBInterfaces.load_from_pk(key)
+    from_db = DBInterfaces.load_from_url(settings.SERVER.url)
+    assert from_key is not None
+    assert from_db is not None

--- a/tests/db/test_issue.py
+++ b/tests/db/test_issue.py
@@ -28,6 +28,9 @@ from .test_user import cmp_user
 
 
 def cmp_issue(lhs: DBIssue, rhs: DBIssue) -> bool:
+    assert lhs is not None
+    assert rhs is not None
+
     return all(
         [
             lhs.title == rhs.title,

--- a/tests/db/test_repo.py
+++ b/tests/db/test_repo.py
@@ -17,6 +17,8 @@ from interface.db.repo import DBRepo
 
 def cmp_repo(lhs: DBRepo, rhs: DBRepo) -> bool:
     """Compare two DBRepo objects"""
+    assert lhs is not None
+    assert rhs is not None
     return all([lhs.name == rhs.name, lhs.owner == rhs.owner])
 
 

--- a/tests/db/test_user.py
+++ b/tests/db/test_user.py
@@ -22,6 +22,9 @@ from interface.auth import KeyPair
 
 
 def cmp_user(lhs: DBUser, rhs: DBUser) -> bool:
+    assert lhs is not None
+    assert rhs is not None
+
     return all(
         [
             lhs.name == rhs.name,

--- a/tests/forges/gitea/test_gitea.py
+++ b/tests/forges/gitea/test_gitea.py
@@ -199,31 +199,6 @@ def test_subscribe(requests_mock):
     assert pytest_expect_errror(error, F_D_FORGE_UNKNOWN_ERROR)
 
 
-def test_get_issue_index(requests_mock):
-    owner = "realaravinth"
-    repo = "tmp"
-
-    issues = [
-        (f"{GITEA_HOST}/{owner}/{repo}/issues/8", 8),
-        (f"{GITEA_HOST}/{owner}/{repo}/issues/8/", 8),
-        (f"{GITEA_HOST}/{owner}/{repo}/issues/9/foo/bar/baz", 9),
-    ]
-
-    for (url, index) in issues:
-        assert Gitea._get_issue_index(url, repo) == index
-
-    not_issues = [
-        f"{GITEA_HOST}/{owner}/{repo}/8",
-        f"{GITEA_HOST}/{owner}/{repo}/issues/foo",
-        f"{GITEA_HOST}/{owner}/{repo}/issues/foo/bar/baz",
-        f"{GITEA_HOST}/{owner}/{repo}/issues/",
-    ]
-    for url in not_issues:
-        with pytest.raises(Error) as error:
-            Gitea._get_issue_index(url, repo)
-        assert pytest_expect_errror(error, F_D_INVALID_ISSUE_URL)
-
-
 def test_html_web_client(requests_mock):
 
     html_client = HTMLClient()

--- a/tests/forges/gitea/test_gitea_utils.py
+++ b/tests/forges/gitea/test_gitea_utils.py
@@ -1,0 +1,48 @@
+# Interface ---  API-space federation for software forges
+# Copyright © 2021 Aravinth Manivannan <realaravinth@batsense.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pytest
+
+from interface.forges.gitea.utils import get_issue_index
+from interface.error import Error
+from interface.forges.base import F_D_INVALID_ISSUE_URL
+
+
+from tests.test_errors import pytest_expect_errror
+from tests.forges.gitea.test_utils import GITEA_HOST
+
+
+def test_get_issue_index():
+    owner = "realaravinth"
+    repo = "tmp"
+
+    issues = [
+        (f"{GITEA_HOST}/{owner}/{repo}/issues/8", 8),
+        (f"{GITEA_HOST}/{owner}/{repo}/issues/8/", 8),
+        (f"{GITEA_HOST}/{owner}/{repo}/issues/9/foo/bar/baz", 9),
+    ]
+
+    for (url, index) in issues:
+        assert get_issue_index(url, repo) == index
+
+    not_issues = [
+        f"{GITEA_HOST}/{owner}/{repo}/8",
+        f"{GITEA_HOST}/{owner}/{repo}/issues/foo",
+        f"{GITEA_HOST}/{owner}/{repo}/issues/foo/bar/baz",
+        f"{GITEA_HOST}/{owner}/{repo}/issues/",
+    ]
+    for url in not_issues:
+        with pytest.raises(Error) as error:
+            get_issue_index(url, repo)
+        assert pytest_expect_errror(error, F_D_INVALID_ISSUE_URL)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,6 @@ def test_auth_key_load_successful(app, requests_mock):
 
 
 def test_auth_key_load_failure(app, requests_mock):
-    settings.PRIVATE_KEY = "foobar"
     with app.app_context():
         with pytest.raises(Exception):
-            KeyPair.loadkey()
+            KeyPair.from_base_64("foobar")

--- a/tests/test_ns.py
+++ b/tests/test_ns.py
@@ -25,7 +25,7 @@ from tests.forges.gitea.test_utils import register_gitea
 def test_ns(app, requests_mock):
     """Test ns"""
     forge = get_forge().forge.get_forge_url()
-    config_interface_url = settings.SERVER.domain
+    config_interface_url = settings.SERVER.url
 
     print(forge)
     ns = NameService(forge)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,7 @@ def register_ns(requests_mock):
     ns = clean_url(settings.SYSTEM.northstar)
     query = f"{ns}/api/v1/forge/interfaces"
     register = f"{ns}/api/v1/interface/register"
-    interface_url = clean_url(settings.SERVER.domain)
+    interface_url = clean_url(settings.SERVER.url)
 
     requests_mock.post(register, json={})
     requests_mock.post(query, json=[interface_url])


### PR DESCRIPTION
## Changes:
- `port`, `ip` in `server` subsection in settings.toml are replaced with a single `url` field: I couldn't come up with an ergonomic way to get scheme(http/https) of the URL and the external port at which the interface will run.
- Interface registers itself(URL and public key) in the database so that comments, repos, issues, etc. that originate from the same interface can be linked against it.
- Delete `local_repositories` and alter `subscriptions` table to depend on 
`gitea_forge_repositories` table instead of the deleted table
- Saving and retrieving subscriptions is implemented as part of the `interface.db` model